### PR TITLE
skip trivial first tokens in parsing

### DIFF
--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -18,10 +18,22 @@ mod template;
 
 pub mod entry {
 
+    use crate::token_kind::TokenKind;
+
     use super::*;
 
     pub fn circom_program(p: &mut Parser) {
         let m = p.open();
+
+        while p.at_any(&[
+            TokenKind::BlockComment,
+            TokenKind::CommentLine,
+            TokenKind::EndLine,
+            TokenKind::WhiteSpace,
+        ]) {
+            p.skip();
+        }
+
         pragma::pragma(p);
         while !p.eof() {
             match p.current() {

--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -4,7 +4,7 @@ use logos::Lexer;
 
 use crate::token_kind::TokenKind;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Input<'a> {
     kind: Vec<TokenKind>,
     source: &'a str,
@@ -71,7 +71,9 @@ impl<'a> Input<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::min;
+    // use std::cmp::min;
+
+    use crate::token_kind::TokenKind;
 
     use super::Input;
 
@@ -83,11 +85,45 @@ mod tests {
     "#
         .to_string();
 
+        let expected_input = Input {
+            kind: vec![
+                TokenKind::EndLine,
+                TokenKind::WhiteSpace,
+                TokenKind::BlockComment,
+                TokenKind::EndLine,
+                TokenKind::WhiteSpace,
+                TokenKind::Identifier,
+                TokenKind::WhiteSpace,
+                TokenKind::Add,
+                TokenKind::WhiteSpace,
+                TokenKind::Number,
+                TokenKind::EndLine,
+                TokenKind::WhiteSpace
+            ],
+            source: &source,
+            position: vec![
+                {0..1},
+                {1..9},
+                {9..24},
+                {24..25},
+                {25..33},
+                {33..34},
+                {34..35},
+                {35..36},
+                {36..37},
+                {37..39},
+                {39..40},
+                {40..44},
+            ]
+        };
+
         let input = Input::new(&source);
 
-        for i in 0..min(input.size(), 10) {
-            println!("kind = {:?}", input.kind[i]);
-            println!("position {:?}", input.position[i]);
-        }
+        assert_eq!(expected_input, input, "Tokens extract from source code are not correct");
+        
+        // for i in 0..min(input.size(), 10) {
+        //     println!("kind = {:?}", input.kind[i]);
+        //     println!("position {:?}", input.position[i]);
+        // }
     }
 }

--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -120,10 +120,5 @@ mod tests {
         let input = Input::new(&source);
 
         assert_eq!(expected_input, input, "Tokens extract from source code are not correct");
-        
-        // for i in 0..min(input.size(), 10) {
-        //     println!("kind = {:?}", input.kind[i]);
-        //     println!("position {:?}", input.position[i]);
-        // }
     }
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -113,7 +113,7 @@ impl<'a> Parser<'a> {
         let mut kind: TokenKind;
         loop {
             kind = self.input.kind_of(self.pos);
-            if !kind.is_travial() {
+            if !kind.is_trivial() {
                 break;
             }
 

--- a/crates/parser/src/token_kind.rs
+++ b/crates/parser/src/token_kind.rs
@@ -248,10 +248,10 @@ impl TokenKind {
     pub fn is_declaration_kw(self) -> bool {
         matches!(self, Self::VarKw | Self::ComponentKw | Self::SignalKw)
     }
-    pub fn is_travial(self) -> bool {
+    pub fn is_trivial(self) -> bool {
         matches!(
             self,
-            Self::WhiteSpace | Self::EndLine | Self::CommentLine | Self::Error
+            Self::WhiteSpace | Self::EndLine | Self::CommentLine | Self::BlockComment | Self::Error
         )
     }
 }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -2,3 +2,5 @@ pub mod syntax;
 pub mod syntax_node;
 
 pub mod abstract_syntax_tree;
+
+pub mod test_programs;

--- a/crates/syntax/src/test_programs.rs
+++ b/crates/syntax/src/test_programs.rs
@@ -1,0 +1,135 @@
+pub const PARSER_TEST_1: &str = r#"pragma circom 2.0.0;
+
+    
+    template Multiplier2 () {}
+    template Multiplier2 () {} 
+    "#;
+
+pub const PARSER_TEST_2: &str = r#"/*
+    Copyright 2018 0KIMS association.
+
+    This file is part of circom (Zero Knowledge Circuit Compiler).
+
+    circom is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    circom is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with circom. If not, see <https://www.gnu.org/licenses/>.
+*/
+/*
+
+Binary Sum
+==========
+
+This component creates a binary sum componet of ops operands and n bits each operand.
+
+e is Number of carries: Depends on the number of operands in the input.
+
+Main Constraint:
+   in[0][0]     * 2^0  +  in[0][1]     * 2^1  + ..... + in[0][n-1]    * 2^(n-1)  +
+ + in[1][0]     * 2^0  +  in[1][1]     * 2^1  + ..... + in[1][n-1]    * 2^(n-1)  +
+ + ..
+ + in[ops-1][0] * 2^0  +  in[ops-1][1] * 2^1  + ..... + in[ops-1][n-1] * 2^(n-1)  +
+ ===
+   out[0] * 2^0  + out[1] * 2^1 +   + out[n+e-1] *2(n+e-1)
+
+To waranty binary outputs:
+
+    out[0]     * (out[0] - 1) === 0
+    out[1]     * (out[0] - 1) === 0
+    .
+    .
+    .
+    out[n+e-1] * (out[n+e-1] - 1) == 0
+
+ */
+
+
+/*
+    This function calculates the number of extra bits in the output to do the full sum.
+ */
+ pragma circom 2.0.0;
+
+function nbits(a) {
+    var n = 1;
+    var r = 0;
+    while (n-1<a) {
+        r++;
+        n *= 2;
+    }
+    return r;
+}
+
+
+template BinSum(n, ops) {
+    var nout = nbits((2**n -1)*ops);
+    signal input in[ops][n];
+    signal output out[nout];
+
+    var lin = 0;
+    var lout = 0;
+
+    var k;
+    var j;
+
+    var e2;
+
+    e2 = 1;
+    for (k=0; k<n; k++) {
+        for (j=0; j<ops; j++) {
+            lin += in[j][k] * e2;
+        }
+        e2 = e2 + e2;
+    
+        e2 = 1;
+        for (k=0; k<nout; k++) {
+            out[k] <-- (lin >> k) & 1;
+    
+            // Ensure out is binary
+            out[k] * (out[k] - 1) === 0;
+    
+            lout += out[k] * e2;
+    
+            e2 = e2+e2;
+        }
+    
+        // Ensure the sum;
+    
+        lin === lout;
+    }
+    "#;
+
+pub const PARSER_TEST_3: &str = r#"
+
+// comment :>
+
+    pragma circom 2.0.0;
+
+    "#;
+
+pub const PARSER_TEST_4: &str = r#"
+
+/*
+comment
+blocks
+*/
+pragma circom 2.0.0;
+    "#;
+
+pub const PARSER_TEST_5: &str = r#"
+// no pragma here
+    template Multiplier2 () {} 
+    "#;
+
+pub const PARSER_TEST_6: &str = r#"
+/* T _ T */
+    template Multiplier2 () {} 
+    "#;
+    


### PR DESCRIPTION
1. Fix typo is_travial –> is_trivial
2. Add BlockComment as a trivial token
3. Skip trivial tokens before pragma
4. Modify test for input (crates/parser/src/input.rs)
5 .Modify test for ast (crates/syntax/src/syntax.rs)